### PR TITLE
Make image appear

### DIFF
--- a/positional-training.html
+++ b/positional-training.html
@@ -312,7 +312,7 @@
             let htmlContent = `
                 <p>${data.description}</p>
                 <div class="player-profile">
-                    <img src="${data.player.img}" alt="${data.player.name}">
+                    <img src="${data.player.img}" alt="${data.player.name}" onerror="this.onerror=null;this.src='https://via.placeholder.com/150?text=Player';">
                     <div class="player-profile-text">
                         <h4>${data.player.name}</h4>
                         <p><strong>ทีม:</strong> ${data.player.team}</p>


### PR DESCRIPTION
Add an `onerror` fallback to player images in `positional-training.html` to display a placeholder when the original image is missing.

Player images were not appearing because the referenced local files (`1558.jpg`, etc.) were not present in the repository. This change ensures that a placeholder image is displayed instead of a broken image icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a035387-5eae-444f-a2fa-5bbcac1f5e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a035387-5eae-444f-a2fa-5bbcac1f5e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

